### PR TITLE
Fix Symbol being stubbed on the window object

### DIFF
--- a/packages/demoboard-runtime/src/createWindowWithStubbedNavigation.ts
+++ b/packages/demoboard-runtime/src/createWindowWithStubbedNavigation.ts
@@ -155,7 +155,7 @@ export function createWindowWithStubbedNavigation(
       }
 
       var result = target[name]
-      if (name !== 'Promise' && typeof result === 'function') {
+      if (!['Promise', 'Symbol'].includes(name) && typeof result === 'function') {
         var cached = windowBoundFunctions[name]
         if (cached) {
           return cached


### PR DESCRIPTION
This fixes the following error:
```
TypeError: Cannot read property 'Symbol(Symbol.toPrimitive)' of undefined
```
Sample file
```js
import React from "react";
import Slider from "rc-slider";
render(<Slider />, document.getElementById("root"));
```
Demoboard link: https://frontarm.com/demoboard/?id=12cbb3ce-9774-4cbd-9fa7-d59729a69907