### PR TITLE
Fixed url change error

### DIFF
--- a/packages/demoboard-ui/src/components/navigationBar/navigationBar.tsx
+++ b/packages/demoboard-ui/src/components/navigationBar/navigationBar.tsx
@@ -133,7 +133,7 @@ export function useProjectNavigationBarState(
     event => {
       dispatch({
         type: 'history.setLocationBar',
-        value: event.target.value,
+        value: event,
       })
     },
     [dispatch],


### PR DESCRIPTION
It wasn't letting me update the url input field and was giving me an error when I tried updating it telling me 'event.target.value' was undefined. Reducing it to just 'event' fixes the problem.